### PR TITLE
feat: replace import with require syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-import cron from 'cron'
-import moment from 'moment'
-import Parse from 'parse/node'
-import rp from 'request-promise'
+const cron = require('cron')
+const moment = require('moment')
+const Parse = require('parse/node')
+const rp = require('request-promise')
 
 const CronJob = cron.CronJob
 const PARSE_TIMEZONE = 'UTC'


### PR DESCRIPTION
Hi, this is a really convenient library and saved me a lot of time!

However, the current version doesn't run in Node.js v12.18.2 since it uses the ES module syntax. In this PR I changed the `import` syntax to `require` to support CommonJS.

Thank you!